### PR TITLE
Adds github actions

### DIFF
--- a/.github/workflows/development_workflow.yml
+++ b/.github/workflows/development_workflow.yml
@@ -31,7 +31,5 @@ jobs:
         run: pip install flake8
       - name: Run flake8
         uses: suo/flake8-github-action@releases/v1
-        with:
-          checkName: "flake8_py3" # NOTE: this needs to be the same as the job name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/development_workflow.yml
+++ b/.github/workflows/development_workflow.yml
@@ -1,0 +1,37 @@
+name: Tests & Formatting
+
+on: [push, pull_request]
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: psf/black@stable
+
+  flake8:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+    steps:
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:
+          checkName: "flake8_py3" # NOTE: this needs to be the same as the job name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/development_workflow.yml
+++ b/.github/workflows/development_workflow.yml
@@ -14,22 +14,3 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: psf/black@20.8b1
-
-  flake8:
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.7]
-    steps:
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@v2
-      - name: Install flake8
-        run: pip install flake8
-      - name: Run flake8
-        uses: suo/flake8-github-action@releases/v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/development_workflow.yml
+++ b/.github/workflows/development_workflow.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: psf/black@stable
+      - uses: psf/black@20.8b1
 
   flake8:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Tests & Formatting
+name: Linting
 
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on: [push, pull_request]
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+    steps:
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Install pipenv
+        run: pip install pipenv
+      - name: Install development dependencies
+        run: pipenv install --dev
+      - name: Copy .env file
+        run: cp .example.env .env
+      - name: Run tests
+        run: pipenv run test

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,3 @@
 [settings]
 line_length=88
+known_third_party = utils

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,18 @@
 # isort
+repos:
 - repo: https://github.com/asottile/seed-isort-config
-  rev: v1.9.3
+  rev: v2.2.0
   hooks:
     - id: seed-isort-config
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+  rev: v5.6.4
   hooks:
     - id: isort
 
 # black
 - repo: https://github.com/ambv/black
-  rev: stable
+  rev: 20.8b1
   hooks:
     - id: black
       args:
@@ -33,7 +34,7 @@
 
 # flake8
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 3.8.4
   hooks:
     - id: flake8
       args:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 6. Test setup: `pipenv run main`
 <br>
 
-7. Install Git hooks. They help you to execute tasks before your code is committed (see [Working with Git](#working-with-git)). Learn more about pre-commit in the [official docs](https://pre-commit.com/). In our case they are used to make sure that the application code is well formatted using [black](https://github.com/psf/black)/[autopep8](https://github.com/hhatto/autopep8), has no syntax errors using [flake8](https://gitlab.com/pycqa/flake8) and that the dependency imports are well sorted using [isort](https://github.com/PyCQA/isort). The pre-commit instructions are given by the `.pre-commit-config.yaml`. Any isort specific settings are given by the `.isort.cfg` file.
+7. Install Git hooks. They help you to execute tasks before your code is committed (see [Working with Git](#working-with-git)). Learn more about pre-commit in the [official docs](https://pre-commit.com/). ([Installation](https://pre-commit.com/#installation) and [Activation](https://pre-commit.com/#3-install-the-git-hook-scripts) are described here) In our case they are used to make sure that the application code is well formatted using [black](https://github.com/psf/black)/[autopep8](https://github.com/hhatto/autopep8), has no syntax errors using [flake8](https://gitlab.com/pycqa/flake8) and that the dependency imports are well sorted using [isort](https://github.com/PyCQA/isort). The pre-commit instructions are given by the `.pre-commit-config.yaml`. Any isort specific settings are given by the `.isort.cfg` file.
 
 **Note:** To deactivate the environment again, simply run `deactivate`.
 
@@ -31,7 +31,7 @@ To generate a report on code coverage alongside run: `pipenv run test && pipenv 
 
 ## Working with Git
 
-In case you do not know about Git yet it is now time to make yourself familiar with it :) 
+In case you do not know about Git yet it is now time to make yourself familiar with it :)
 There are already plenty of very good tutorials about Git out there which is why  we refer to them. For a good introduction written in German you might want to go to [Roger Dudler's awesome post](https://rogerdudler.github.io/git-guide/index.de.html).
 
 ### Git Workflow
@@ -42,7 +42,7 @@ To coordinate the software development process a set of guidelines are necessary
 2. Create an issue that describes a bug or asks for an additional feature.
 3. Add features or solve bug fixes by creating new branches via `git checkout`. Those branches should be named `feature-*` or `fix-*` accordingly. Assign the issue that the code changes are meant to solve.
 4. Commit to new feature or fix branch. Make sure that you also write `tests` which cover the new features or show that the bug is solved. They should run automatically using the [GitHub CI system](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-continuous-integration). Having a CI system set up is not mandatory but helps a lot to avoid mistakes during the development process.
-5. Create pull request once you are done with your work. Use the @mention system to get the maintainer's attention or ask questions to specific people. 
+5. Create pull request once you are done with your work. Use the @mention system to get the maintainer's attention or ask questions to specific people.
 6. Optional discussion about the pull request. If necessary, additional changes can be made.
 7. New branch is merged into `main/master` branch.
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,8 @@ if __name__ == "__main__":
     # run example function
     hello_world_success = hello_world()
     print("Hello World completed successfully!") if hello_world_success else print(
-        "Hello Wold failed!")
+        "Hello Wold failed!"
+    )
 
     # exemplify how to access environment variables
     print("\nEnvironment variable: {}".format(os.environ["TEST_PW"]))

--- a/tests/sample_test.py
+++ b/tests/sample_test.py
@@ -12,5 +12,5 @@ class TestTest(unittest.TestCase):
         self.assertTrue(True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi @jomazi,
this PR adds the necessary workflow files to enable Github Actions for running black and the tests. 

It was necessary to run `precommit-autoupdate` to pin the version number of black as described in 270eb49. The new version makes some minor changes to the formatting of the code.

PS: I've added are more obvious hint that it is necessary to actively install and activate the precommit-hooks.